### PR TITLE
Implement multi-filter batch convolution.

### DIFF
--- a/simulation/complex_convolution.py
+++ b/simulation/complex_convolution.py
@@ -25,7 +25,7 @@ def convolve_complex_1d(
 
   Raises:
     ValueError: If `tensor` and `filter` do not have compatible dtype or if
-      `filters` is not 1D.
+      `filter` has incorrect shape.
   """
   if tensor.dtype != filter.dtype:
     raise ValueError("`tensor` and `filter` must have same dtype got `{}`"

--- a/simulation/complex_convolution_test.py
+++ b/simulation/complex_convolution_test.py
@@ -17,12 +17,12 @@ class ComplexConvolutionTest(tf.test.TestCase):
   ])
   def testConvolutionReal(self, stride, padding):
     tensor = tf.random_uniform([10])
-    filter = tf.random_uniform([3])
+    filter = tf.random_uniform([3, 4])
     convolved = complex_convolution.convolve_complex_1d(tensor, filter, stride,
                                                         padding)
     normal_convolve_1d = tf.nn.conv1d(
-      tensor[tf.newaxis, :, tf.newaxis], filter[:, tf.newaxis, tf.newaxis],
-      stride, padding)[0, :, 0]
+      tensor[tf.newaxis, :, tf.newaxis], filter[:, tf.newaxis, :],
+      stride, padding)[0, :, :]
     with self.test_session() as sess:
       convolved_eval, true_value = sess.run([convolved, normal_convolve_1d])
       self.assertAllClose(convolved_eval, true_value)
@@ -35,12 +35,12 @@ class ComplexConvolutionTest(tf.test.TestCase):
   ])
   def testConvolutionNDwith1D(self, stride, padding):
     tensor = tf.random_uniform([2, 10])
-    filter = tf.random_uniform([3])
+    filter = tf.random_uniform([3, 4])
     convolved = complex_convolution.convolve_complex_1d(tensor, filter, stride,
                                                         padding)
     normal_convolve_1d = tf.nn.conv1d(
-      tensor[..., tf.newaxis], filter[:, tf.newaxis, tf.newaxis],
-      stride, padding)[..., 0]
+      tensor[..., tf.newaxis], filter[:, tf.newaxis, :],
+      stride, padding)
     with self.test_session() as sess:
       convolved_eval, true_value = sess.run([convolved, normal_convolve_1d])
       self.assertAllClose(convolved_eval, true_value)
@@ -53,25 +53,25 @@ class ComplexConvolutionTest(tf.test.TestCase):
   ])
   def testConvolutionNDwith1DComplex(self, stride, padding):
     tensor = tf.random_uniform([2, 10])
-    filter = tf.random_uniform([3])
+    filter = tf.random_uniform([3, 3])
     convolved = complex_convolution.convolve_complex_1d(
       tf.complex(real=tf.zeros_like(tensor), imag=tensor),
       tf.cast(filter, tf.complex64), stride,
       padding)
     normal_convolve_1d = tf.nn.conv1d(
-      tensor[..., tf.newaxis], filter[:, tf.newaxis, tf.newaxis],
-      stride, padding)[..., 0]
+      tensor[..., tf.newaxis], filter[:, tf.newaxis, :],
+      stride, padding)
     with self.test_session() as sess:
       convolved_eval, true_value = sess.run([convolved, normal_convolve_1d])
       self.assertAllClose(np.abs(convolved_eval), true_value)
 
   def testConvolutionComplex(self):
     tensor = tf.constant([1 + 2j, 0., 1j, 1 + 3j], dtype=tf.complex64)
-    filter = tf.constant([2j, 3.])
+    filter = tf.constant([[0.+2.j, 0.+1.j], [3.+0.j, 2.+1.j]])
     convolved = complex_convolution.convolve_complex_1d(tensor,
                                                         tf.cast(filter,
                                                                 tf.complex64))
-    truth_value = [-4 + 2j, 3j, 1 + 9j]
+    truth_value = [[-4.+2.j, -2.+1.j], [ 0.+3.j, -1.+2.j], [ 1.+9.j, -2.+7.j]]
     with self.test_session() as sess:
       convolved_eval = sess.run(convolved)
       self.assertAllClose(np.real(convolved_eval), np.real(truth_value))
@@ -79,21 +79,22 @@ class ComplexConvolutionTest(tf.test.TestCase):
 
   def testInvalidPadding(self):
     tensor = tf.constant([1., 2.])
-    filter = tf.constant([1., 2.])
+    filter = tf.constant([[1., 2.]])
     with self.assertRaisesRegex(ValueError, "`padding` must be one of"):
       complex_convolution.convolve_complex_1d(tensor, filter,
                                               padding="NotValid")
 
   def testInvalidKernel(self):
     tensor = tf.constant([1., 2.])
-    filter = tf.constant([[1., 2.]])
-    with self.assertRaisesRegex(ValueError, "Shapes \(1, 2\) and \[None\]"):
+    filter = tf.constant([1., 2.])
+    with self.assertRaisesRegex(ValueError,
+                                "Shapes \(2,\) and \[None, None\]"):
       complex_convolution.convolve_complex_1d(tensor, filter, )
 
   def testInvalidDtypes(self):
     tensor = tf.constant([1., 2.], dtype=tf.float32)
-    filter = tf.constant([1., 2.], dtype=tf.float64)
-    with self.assertRaisesRegex(ValueError, "`tensor` and `filters` must"):
+    filter = tf.constant([[1., 2.]], dtype=tf.float64)
+    with self.assertRaisesRegex(ValueError, "`tensor` and `filter` must"):
       complex_convolution.convolve_complex_1d(tensor, filter, )
 
 

--- a/simulation/complex_convolution_test.py
+++ b/simulation/complex_convolution_test.py
@@ -67,11 +67,12 @@ class ComplexConvolutionTest(tf.test.TestCase):
 
   def testConvolutionComplex(self):
     tensor = tf.constant([1 + 2j, 0., 1j, 1 + 3j], dtype=tf.complex64)
-    filter = tf.constant([[0.+2.j, 0.+1.j], [3.+0.j, 2.+1.j]])
+    filter = tf.constant([[0. + 2.j, 0. + 1.j], [3. + 0.j, 2. + 1.j]])
     convolved = complex_convolution.convolve_complex_1d(tensor,
                                                         tf.cast(filter,
                                                                 tf.complex64))
-    truth_value = [[-4.+2.j, -2.+1.j], [ 0.+3.j, -1.+2.j], [ 1.+9.j, -2.+7.j]]
+    truth_value = [[-4. + 2.j, -2. + 1.j], [0. + 3.j, -1. + 2.j],
+                   [1. + 9.j, -2. + 7.j]]
     with self.test_session() as sess:
       convolved_eval = sess.run(convolved)
       self.assertAllClose(np.real(convolved_eval), np.real(truth_value))


### PR DESCRIPTION
CONTEXT: The image formation process is modeled by convolving a complex PSF with the scatterer distribution. In order to represent more orthogonal speckle patterns we will have to use multiple frequencies. This is equivalent to using multiple psfs when forming the image.

SCOPE: Previously we could only convolve a single filter at a time with a batch of images.  This CL implements multi-filter convolution.