### PR TITLE
Implement new `psf_utils` module.

### DIFF
--- a/simulation/psf_utils.py
+++ b/simulation/psf_utils.py
@@ -28,8 +28,7 @@ def to_filter(
       }
 
   This is useful when applying multiple filters (for example, when trying
-  to simulate multiple observation frequencies) in an observation. The output
-  of
+  to simulate multiple observation frequencies) in an observation.
 
   Args:
     psfs: List of 1D arrays representing the PSF of an imaging device.
@@ -40,7 +39,7 @@ def to_filter(
     Array of shape `[length, channels_in, channels_out]`.
 
   Raises:
-    ValueError: If all psf's are not the same length. Or mode arg is invalid.
+    ValueError: If all PSF are not the same length. Or mode arg is invalid.
     """
   if any(len(psf.shape) > 1 for psf in psfs):
     raise ValueError("All PSF's must be 1D, got {}.".format(

--- a/simulation/psf_utils.py
+++ b/simulation/psf_utils.py
@@ -1,0 +1,64 @@
+"""Utilities for constructing psf filters."""
+
+import numpy as np
+
+from typing import List
+
+_FROM_SAME = "FROM_SAME"
+_FROM_SINGLE = "FROM_SINGLE"
+
+
+def to_filter(
+    psfs: List[np.ndarray],
+    mode: str,
+) -> np.ndarray:
+  """Constructs a single filter from a list of psfs.
+  
+  This function builds a filter of shape `[length, channels_in, channels_out]`.
+
+  In mode `FROM_SINGLE` this constructs a filter with one input channel and
+  `len(psfs)` output channels.
+
+  In mode `FROM_SAME`, the number of input and output channels are the same and
+  each psf represents a map from one channel to the same channel in the output.
+   In other words,
+    F_{l, i, j} = {
+        if i == j: psf[l]
+        if i != j: [0]
+      }
+
+  This is useful when applying multiple filters (for example, when trying
+  to simulate multiple observation frequencies) in an observation. The output
+  of
+
+  Args:
+    psfs: List of 1D arrays representing the PSF of an imaging device.
+    mode: String representing type of filter. Must be one of `FROM_SINGLE`,
+    `FROM_SAME`.
+
+  Returns:
+    Array of shape `[length, channels_in, channels_out]`.
+
+  Raises:
+    ValueError: If all psf's are not the same length. Or mode arg is invalid.
+    """
+  if any(len(psf.shape) > 1 for psf in psfs):
+    raise ValueError("All PSF's must be 1D, got {}.".format(
+      [psf.shape for psf in psfs]))
+  if any(psf.shape != psfs[0].shape for psf in psfs):
+    raise ValueError("All PSF's must have same shape, got {}.".format(
+      [psf.shape for psf in psfs]
+    ))
+
+  # Stack filters and add `in_channel` dimension.
+  filter = np.stack(psfs, -1)[..., np.newaxis, :]
+
+  if mode == _FROM_SINGLE:
+    return filter
+  if mode == _FROM_SAME:
+    # Tile `filter` so `in_channels` has same dimension as `out_channels`.
+    filter = np.tile(filter, [1, len(psfs), 1])
+    return filter * np.eye(len(psfs))[np.newaxis, ...]
+  else:
+    raise ValueError("`mode` must be one of {} but got `{}`".format(
+      [_FROM_SAME, _FROM_SINGLE], mode))

--- a/simulation/psf_utils_test.py
+++ b/simulation/psf_utils_test.py
@@ -1,0 +1,48 @@
+"""Tests for `psf_utils`."""
+
+import unittest
+import numpy as np
+
+from simulation import psf_utils
+
+
+class PsfUtilsTest(unittest.TestCase):
+
+  def testSameMode(self):
+    psfs = [np.random.rand(10) for _ in range(5)]
+    filter = psf_utils.to_filter(psfs, 'FROM_SAME')
+    self.assertEqual(filter.shape, (10, 5, 5))
+    for in_channel_iter in range(5):
+      for filter_iter in range(5):
+        if in_channel_iter == filter_iter:
+          np.testing.assert_allclose(
+            filter[:, in_channel_iter, filter_iter], psfs[in_channel_iter])
+        else:
+          np.testing.assert_equal(
+            filter[:, in_channel_iter, filter_iter], np.zeros_like(psfs[0]))
+
+  def testFromSingleMode(self):
+    psfs = [np.random.rand(10) for _ in range(5)]
+    filter = psf_utils.to_filter(psfs, 'FROM_SINGLE')
+    self.assertEqual(filter.shape, (10, 1, 5))
+    for filter_iter in range(5):
+      np.testing.assert_allclose(filter[:, 0, filter_iter], psfs[filter_iter])
+
+  def testBadMode(self):
+    mode = "NOT_A_MODE"
+    with self.assertRaisesRegex(ValueError, "`mode` must be one of"):
+      psf_utils.to_filter([np.ones(1)], mode)
+
+  def testIncompatiblePSFLength(self):
+    psfs = [np.ones(12), np.ones(5)]
+    with self.assertRaisesRegex(ValueError, "All PSF's must have same shape"):
+      psf_utils.to_filter(psfs, "FROM_SAME")
+
+  def testIncompatiblePSFDimension(self):
+    psfs = [np.ones((12, 5)), np.ones((12, 5))]
+    with self.assertRaisesRegex(ValueError, "All PSF's must be 1D"):
+      psf_utils.to_filter(psfs, "FROM_SAME")
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
CONTEXT: `psf_utils` contains functions for preparing psfs for use in observation simulations.

SCOPE: `psf_utils` contains `to_filter` which takes a list of psfs and builds a filter. This can be used, for example, when making the lateral and axial psfs.