### PR TITLE
Move `ObservationSpec` to `defs`.

### DIFF
--- a/simulation/defs.py
+++ b/simulation/defs.py
@@ -1,3 +1,31 @@
 """Common defintions."""
 
+from collections import namedtuple
+import numpy as np
+
 _SPEED_OF_SOUND_WATER = 1498  # m/s
+
+
+class ObservationSpec(namedtuple(
+  'ObservationSpec', ['angles', 'frequencies', 'grid_dimension',
+                      'transducer_bandwidth', 'numerical_aperture'])):
+  """ObservationSpec contains parameters associated with US observation."""
+
+  def __new__(cls, angles, frequencies, grid_dimension, transducer_bandwidth,
+              numerical_aperture):
+    assert isinstance(angles, list)
+    if not all(0. <= angle < np.pi for angle in angles):
+      raise ValueError("All angle in `angles` must be scalars between 0 and "
+                       "pi. Got {}.".format(angles))
+
+    assert isinstance(frequencies, list)
+
+    assert isinstance(grid_dimension, float)
+
+    assert isinstance(transducer_bandwidth, float)
+
+    assert isinstance(numerical_aperture, float)
+
+    return super(ObservationSpec, cls).__new__(
+      cls, angles, frequencies, grid_dimension, transducer_bandwidth,
+      numerical_aperture)

--- a/simulation/observation.py
+++ b/simulation/observation.py
@@ -6,7 +6,6 @@ from typing import Optional, Tuple
 from simulation import complex_convolution
 from simulation import tensor_utils
 
-
 def observe(
     state: tf.Tensor,
     psf_lateral: tf.Tensor,

--- a/simulation/psf_utils.py
+++ b/simulation/psf_utils.py
@@ -3,10 +3,15 @@
 import numpy as np
 
 from typing import List
+
+from simulation import defs
 from simulation import response_functions
+from simulation import estimator
 
 _FROM_SAME = "FROM_SAME"
 _FROM_SINGLE = "FROM_SINGLE"
+_LATERAL = "LATERAL"
+_AXIAL = "AXIAL"
 
 
 def to_filter(
@@ -96,3 +101,17 @@ def axial_psf_filters(
     for wavelength in wavelengths]
   return to_filter(psf_axial, mode="FROM_SAME")
 
+def psf_filter(
+    type: str,
+    length: int,
+    observation_spec: defs.ObservationSpec,
+):
+  """Convenience function to construct psf filter from `ObservationSpec`."""
+  wavelengths = [defs._SPEED_OF_SOUND_WATER / freq for freq in
+                 observation_spec.frequencies]
+  if type == _LATERAL:
+    return lateral_psf_filters(length, wavelengths, observation_spec.numerical_aperture, observation_spec.grid_dimension,)
+  if type == _AXIAL:
+    return axial_psf_filters(length, wavelengths, observation_spec.numerical_aperture, observation_spec.transducer_bandwidth, observation_spec.grid_dimension)
+  else:
+    raise ValueError("`type` must be one of {}, got {}".format([_LATERAL, _AXIAL], type))

--- a/simulation/psf_utils_test.py
+++ b/simulation/psf_utils_test.py
@@ -4,7 +4,7 @@ import unittest
 import numpy as np
 
 from simulation import psf_utils
-
+from simulation import estimator_test
 
 class PsfUtilsTest(unittest.TestCase):
 
@@ -52,6 +52,13 @@ class PsfUtilsTest(unittest.TestCase):
     with self.assertRaisesRegex(
         ValueError, "`psf_length` must be odd."):
       psf_utils.axial_psf_filters(12, [.1, .2], 2., .1, .1)
+
+  def testFromObservationSpec(self):
+    pass
+
+  def testFromObservationSpecBadType(self):
+    with self.assertRaisesRegex(ValueError, "`type` must be one of"):
+      psf_utils.psf_filter("NOT_A_REAL_TYPE", 11, estimator_test.simple_observation_spec())
 
 
 if __name__ == "__main__":

--- a/training_data/generate.py
+++ b/training_data/generate.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 import tensorflow as tf
-from simulation import observation_estimator
+from simulation import estimator
 
 def _bytes_feature(value):
   """Returns a bytes_list from a string / byte."""
@@ -32,7 +32,7 @@ def _int64_list_feature(value):
 def _construct_example(
     distribution: np.ndarray,
     observation: np.ndarray,
-    observation_params: observation_estimator.ObservationSpec
+    observation_params: estimator.ObservationSpec
 ):
   """Constructs `tf.train.Example` for scatterer distribution and simulation.
 

--- a/training_data/generate_test.py
+++ b/training_data/generate_test.py
@@ -5,7 +5,7 @@ import tensorflow as tf
 from parameterized import parameterized
 
 from training_data import generate
-from simulation import observation_estimator
+from simulation import estimator
 
 
 class GenerateTest(tf.test.TestCase):
@@ -22,7 +22,7 @@ class GenerateTest(tf.test.TestCase):
     true_scatter = np.random.rand(*distribution_shape).astype(np.float32)
     true_observation = np.random.rand(*observation_shape).astype(np.float32)
 
-    true_observation_spec = observation_estimator.ObservationSpec([0, np.pi / 2], [1.5], .23, .2, .8)
+    true_observation_spec = estimator.ObservationSpec([0, np.pi / 2], [1.5], .23, .2, .8)
     example = generate._construct_example(
       true_scatter, true_observation, true_observation_spec)
 


### PR DESCRIPTION
SCOPE: Move `ObservationSpec` and also implement convenience functions in `psf_utils` to build PSFS from `ObservationSpec` objects.