### PR TITLE
Let `to_filter` operate on arbitrary input dimensions.

### DIFF
--- a/simulation/psf_utils.py
+++ b/simulation/psf_utils.py
@@ -20,7 +20,8 @@ def to_filter(
 ) -> np.ndarray:
   """Constructs a single filter from a list of psfs.
   
-  This function builds a filter of shape `[length, channels_in, channels_out]`.
+  This function builds a filter of shape
+    `input_dimensions + [channels_in, channels_out]`.
 
   In mode `FROM_SINGLE` this constructs a filter with one input channel and
   `len(psfs)` output channels.
@@ -28,8 +29,8 @@ def to_filter(
   In mode `FROM_SAME`, the number of input and output channels are the same and
   each psf represents a map from one channel to the same channel in the output.
    In other words,
-    F_{l, i, j} = {
-        if i == j: psf[l]
+    F_{... , i, j} = {
+        if i == j: psf[i]
         if i != j: [0]
       }
 
@@ -37,19 +38,17 @@ def to_filter(
   to simulate multiple observation frequencies) in an observation.
 
   Args:
-    psfs: List of 1D arrays representing the PSF of an imaging device.
+    psfs: List of arrays with shape `dimensions` representing the PSF of an
+      imaging device.
     mode: String representing type of filter. Must be one of `FROM_SINGLE`,
     `FROM_SAME`.
 
   Returns:
-    Array of shape `[length, channels_in, channels_out]`.
+    Array of shape `dimensions + [channels_in, channels_out]`.
 
   Raises:
     ValueError: If all PSF are not the same length. Or mode arg is invalid.
-    """
-  if any(len(psf.shape) > 1 for psf in psfs):
-    raise ValueError("All PSF's must be 1D, got {}.".format(
-      [psf.shape for psf in psfs]))
+  """
   if any(psf.shape != psfs[0].shape for psf in psfs):
     raise ValueError("All PSF's must have same shape, got {}.".format(
       [psf.shape for psf in psfs]
@@ -63,7 +62,7 @@ def to_filter(
   if mode == _FROM_SAME:
     # Tile `filter` so `in_channels` has same dimension as `out_channels`.
     filter = np.tile(filter, [1, len(psfs), 1])
-    return filter * np.eye(len(psfs))[np.newaxis, ...]
+    return filter * np.eye(len(psfs))
   else:
     raise ValueError("`mode` must be one of {} but got `{}`".format(
       [_FROM_SAME, _FROM_SINGLE], mode))

--- a/simulation/psf_utils_test.py
+++ b/simulation/psf_utils_test.py
@@ -22,12 +22,33 @@ class PsfUtilsTest(unittest.TestCase):
           np.testing.assert_equal(
             filter[:, in_channel_iter, filter_iter], np.zeros_like(psfs[0]))
 
+  def testSameMode2D(self):
+    psfs = [np.random.rand(10, 10) for _ in range(5)]
+    filter = psf_utils.to_filter(psfs, 'FROM_SAME')
+    self.assertEqual(filter.shape, (10, 10, 5, 5))
+    for in_channel_iter in range(5):
+      for filter_iter in range(5):
+        if in_channel_iter == filter_iter:
+          np.testing.assert_allclose(
+            filter[:, :, in_channel_iter, filter_iter], psfs[in_channel_iter])
+        else:
+          np.testing.assert_equal(
+            filter[:, :, in_channel_iter, filter_iter], np.zeros_like(psfs[0]))
+
   def testFromSingleMode(self):
     psfs = [np.random.rand(10) for _ in range(5)]
     filter = psf_utils.to_filter(psfs, 'FROM_SINGLE')
     self.assertEqual(filter.shape, (10, 1, 5))
     for filter_iter in range(5):
       np.testing.assert_allclose(filter[:, 0, filter_iter], psfs[filter_iter])
+
+  def testFromSingleMode2D(self):
+    psfs = [np.random.rand(10, 10) for _ in range(5)]
+    filter = psf_utils.to_filter(psfs, 'FROM_SINGLE')
+    self.assertEqual(filter.shape, (10, 10, 1, 5))
+    for filter_iter in range(5):
+      np.testing.assert_allclose(filter[:, :, 0, filter_iter], psfs[filter_iter])
+
 
   def testBadMode(self):
     mode = "NOT_A_MODE"
@@ -37,11 +58,6 @@ class PsfUtilsTest(unittest.TestCase):
   def testIncompatiblePSFLength(self):
     psfs = [np.ones(12), np.ones(5)]
     with self.assertRaisesRegex(ValueError, "All PSF's must have same shape"):
-      psf_utils.to_filter(psfs, "FROM_SAME")
-
-  def testIncompatiblePSFDimension(self):
-    psfs = [np.ones((12, 5)), np.ones((12, 5))]
-    with self.assertRaisesRegex(ValueError, "All PSF's must be 1D"):
       psf_utils.to_filter(psfs, "FROM_SAME")
 
   def testBadLateralShape(self):


### PR DESCRIPTION
CONTEXT: `to_filter` turns a list of psfs into a filter compatible with a convolution (for simulation).

SCOPE: Previously `to_filter` only operated on 1D filters. This CL adds compatibility with multi-dimensional (specifically we will use 2D inoputs) psfs.