### PR TITLE
Implement numpy equivalent of `tf.nn.conv2d`.

### DIFF
--- a/utils/numpy_convolution.py
+++ b/utils/numpy_convolution.py
@@ -1,0 +1,80 @@
+"""Fast numpy convolution operations."""
+
+import math
+
+import numpy as np
+
+from scipy import signal
+
+_VALID = "VALID"
+_SAME = "SAME"
+
+
+def convolve_2d(
+    tensor: np.ndarray,
+    filter: np.ndarray,
+    padding: str,
+) -> np.ndarray:
+  """Computes 2D convolution in style of `tf.nn.convolve2d`.
+
+  Args:
+    tensor: Array with shape `[batch, height, width, channel]`.
+    filter: Array with shape
+      `[filter_height, filter_width, in_channel, out_channels]`.
+    padding: One of `SAME`, `VALID`.
+
+  Returns:
+    Result of convolving `tensor` with `filter`.
+
+  Raises:
+      `ValueError` if `filter` or `tensor` have incorrect shape.
+  """
+  if tensor.dtype != filter.dtype:
+    raise ValueError("`tensor` and `filter` must have same dtype got `{}`"
+                     "".format([tensor.dtype, filter.dtype]))
+  if len(filter.shape) != 4:
+    raise ValueError("`filter` must have shape "
+                     "[height, width, channel_in, channel_out]`")
+  if filter.shape[-2] != tensor.shape[-1]:
+    raise ValueError("`filter` and `tensor` must have same number of "
+                     "`channel_in`")
+
+  filter_lengths = filter.shape[:2]
+
+  # Pad spatial axes given desired output.
+  spatial_pads = [
+    _pads(axis_length, padding) for axis_length in filter_lengths]
+
+  # We do not want to pad either `batch` or `filter` axes.
+  pads = [[0, 0]] + spatial_pads + [[0, 0]]
+
+  tensor = np.pad(tensor, pads, mode="constant")
+
+  # Add `batch` dimension to `filter`.
+  filter = filter[np.newaxis, ...]
+
+  # We iterate over `channel_out` axis to make a stack with elements corresponding
+  # to individual `channel_out` filters.
+  conv_list = [
+    signal.correlate(tensor, filter_slice, mode="valid", method="auto")
+    for filter_slice
+    in [filter[..., out_channel] for out_channel in range(filter.shape[-1])]
+  ]
+
+  return np.concatenate(conv_list, -1)
+
+
+# TODO(noah): implement other stride lengths
+def _pads(
+    filter_length: int,
+    mode:str,
+):
+  """Computes zero-padding given filter length and mode."""
+  if mode==_VALID:
+    return [0, 0]
+  if mode==_SAME:
+    total_pad = float(filter_length - 1)
+    pad_top = math.floor(total_pad / 2.)
+    pad_bottom = math.ceil(total_pad / 2.)
+    return [pad_top, pad_bottom]
+

--- a/utils/numpy_convolution_test.py
+++ b/utils/numpy_convolution_test.py
@@ -1,0 +1,49 @@
+"""Tests for `numpy_convolution`."""
+
+import unittest
+import numpy as np
+import tensorflow as tf
+
+from parameterized import parameterized
+
+
+from utils import numpy_convolution
+
+class ConvolutionTest(unittest.TestCase):
+
+  def TestPadValid(self):
+    np.testing.assert_allclose([0, 0], numpy_convolution._pads(10, "VALID"))
+
+  def testPadSame(self):
+    filter_length = 4
+    np.testing.assert_allclose([1, 2],
+                               numpy_convolution._pads(filter_length, "SAME"))
+
+  @parameterized.expand([
+    (np.ones([1, 14, 14, 1]), np.ones([1, 1, 1, 1])),
+    (np.random.rand(*[15, 32, 32, 1]),
+     np.random.rand(*[5, 5, 1, 1])), # Batch dimension.
+    (np.random.rand(*[15, 32, 32, 4]),
+     np.random.rand(*[5, 5, 4, 1])), # Multi-channel in.
+    (np.random.rand(*[15, 32, 32, 3]),
+     np.random.rand(*[5, 5, 3, 7])),  # Multi-channel out.
+    (np.random.rand(*[15, 32, 32, 4]),
+     np.random.rand(*[8, 8, 4, 7])),  # Even dimensions.
+    (np.random.rand(*[15, 32, 32, 4]),
+     np.random.rand(*[7, 7, 4, 7])),  # Odd dimensions.
+    (np.random.rand(*[1, 500, 500, 1]),
+     np.random.rand(*[50, 50, 1, 1])),  # Large.
+  ])
+  def testConvolveValid(self, tensor, filter):
+    conv = numpy_convolution.convolve_2d(tensor, filter, padding="VALID")
+
+    tf_conv = tf.nn.conv2d(tensor, filter, strides=[1]*4, padding="VALID")
+
+    with tf.Session() as sess:
+      tf_conv_eval = sess.run(tf_conv)
+
+    np.testing.assert_allclose(tf_conv_eval, conv)
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
CONTEXT: Scipy version of convolution is faster than tf, however it has a different function signature and slightly different treatment of edges/padding. Therefore this cl implements a wrapper that emulates the functionality of `tf.nn.conv2d`.

SCOPE: Implement `convolve_2d` which emulates performance of `tf.nn.conv2d`.