### PR TITLE
Move saving functionality to `numpy_dataset_utils`.

### DIFF
--- a/training_data/numpy_dataset_utils.py
+++ b/training_data/numpy_dataset_utils.py
@@ -1,0 +1,43 @@
+"""Functions for saving datasets consisting of numpy arrays."""
+
+import math
+import os
+
+import numpy as np
+
+
+def save_dataset(
+  generator,
+  count,
+  shard_size,
+  save_directory,
+  file_prefix,
+):
+  """Saves datset of elements from generator.
+
+  This function builds and saves a dataset of scatterer distributions given
+  a generator which produces np.ndarrays contining scatterer distributions.
+
+  Each shard contains a single np.ndarrays with shape
+  `[shard_size] + generator_output_shape`. This implies that the generator must
+  return a consistent array size.
+
+  Args:
+    generator: Generator which returns np.ndarray objects.
+    count: Total number of distributions in dataset.
+    shard_size: Number of distributions per shard.
+    save_directory: Path to folder where data will be saved.
+    file_prefix: Optional prefix to add to filenames.
+
+  Raises:
+    ValueError if `save_directory` is not valid.
+  """
+  if not os.path.isdir(save_directory):
+    raise ValueError("`save_directory` must be a valid directory.")
+
+  file_count = int(math.ceil(float(count) / shard_size))
+  for shard in range(1, file_count + 1):
+    output = np.stack([next(generator) for _ in range(shard_size)], 0)
+    filename = "%s_%d_of_%d.npy" % (file_prefix, shard, file_count)
+    output_file = os.path.join(save_directory, filename)
+    np.save(output_file, output)

--- a/training_data/numpy_dataset_utils_test.py
+++ b/training_data/numpy_dataset_utils_test.py
@@ -1,0 +1,33 @@
+"""Tests for `numpy_dataset_utils.py`"""
+
+import glob
+import shutil
+import tempfile
+import unittest
+
+import numpy as np
+
+from training_data import numpy_dataset_utils
+
+
+class DatsetUtilsTest(unittest.TestCase):
+
+  def setUp(self):
+    self.test_dir = tempfile.mkdtemp()
+
+  def tearDown(self):
+    # Remove the directory after the test
+    shutil.rmtree(self.test_dir)
+
+  def testGeneratorSave(self):
+    data = [np.random.rand(40, 40) for _ in range(200)]
+    gen = iter(data)
+    numpy_dataset_utils.save_dataset(gen, 200, 40, self.test_dir, "test_prefix")
+    files = sorted(glob.glob(self.test_dir + "/*"))
+    self.assertEqual(len(files), 5)
+    loaded = np.concatenate([np.load(file) for file in files], 0)
+    np.testing.assert_equal(np.stack(data, 0), loaded)
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/training_data/shapes_dataset.py
+++ b/training_data/shapes_dataset.py
@@ -95,7 +95,7 @@ def random_circles(
     # Add circle.
     box += _circle(coordinates, origin, radius) * intensity
 
-  return np.clip(box, a_max=max_intensity)
+  return np.clip(box, a_min=0., a_max=max_intensity)
 
 
 def shape_generator(
@@ -117,38 +117,3 @@ def shape_generator(
   while True:
     yield shape_fn(*args, **kwargs)
 
-def save_dataset(
-  generator,
-  count,
-  shard_size,
-  save_directory,
-  file_prefix,
-):
-  """Saves datset of elements from generator.
-
-  This function builds and saves a dataset of scatterer distributions given
-  a generator which produces np.ndarrays contining scatterer distributions.
-
-  Each shard contains a single np.ndarrays with shape
-  `[shard_size] + generator_output_shape`. This implies that the generator must
-  return a consistent array size.
-
-  Args:
-    generator: Generator which returns np.ndarray objects.
-    count: Total number of distributions in dataset.
-    shard_size: Number of distributions per shard.
-    save_directory: Path to folder where data will be saved.
-    file_prefix: Optional prefix to add to filenames.
-
-  Raises:
-    ValueError if `save_directory` is not valid.
-  """
-  if not os.path.isdir(save_directory):
-    raise ValueError("`save_directory` must be a valid directory.")
-
-  file_count = int(math.ceil(float(count) / shard_size))
-  for shard in range(1, file_count + 1):
-    output = np.stack([next(generator) for _ in range(shard_size)], 0)
-    filename = "%s_%d_of_%d.npy" % (file_prefix, shard, file_count)
-    output_file = os.path.join(save_directory, filename)
-    np.save(output_file, output)

--- a/training_data/shapes_datset_test.py
+++ b/training_data/shapes_datset_test.py
@@ -1,8 +1,5 @@
 """Tests for shapes_dataset.py"""
 
-import glob
-import shutil
-import tempfile
 import unittest
 
 
@@ -18,24 +15,6 @@ class shapesTest(unittest.TestCase):
   def testCircleBadDimensions(self):
     pass
 
-
-class generatorTest(unittest.TestCase):
-
-  def setUp(self):
-    self.test_dir = tempfile.mkdtemp()
-
-  def tearDown(self):
-    # Remove the directory after the test
-    shutil.rmtree(self.test_dir)
-
-  def testGeneratorSave(self):
-    data = [np.random.rand(40, 40) for _ in range(200)]
-    gen = iter(data)
-    shapes_dataset.save_dataset(gen, 200, 40, self.test_dir, "test_prefix")
-    files = sorted(glob.glob(self.test_dir + "/*"))
-    self.assertEqual(len(files), 5)
-    loaded = np.concatenate([np.load(file) for file in files], 0)
-    np.testing.assert_equal(np.stack(data, 0), loaded)
 
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
CONTEXT: `numpy_dataset_utils` is a general package for writing numpy datasets (which will be used to store scatterer distributions) to disk.