### PR TITLE
Add `pad_and_trim` option to `rotate_tensor_np`.

### DIFF
--- a/simulation/observation.py
+++ b/simulation/observation.py
@@ -251,14 +251,14 @@ def rotate_and_observe_np(
   state = np.tile(state, [1, len(angles), 1, 1, 1])
 
   # Rotate images along `angle` dimension.
-  state = tensor_utils.rotate_tensor_np(state, angles, 1)
+  state = tensor_utils.rotate_tensor_np(state, angles, 1, pad_and_trim=True)
 
   # Observation.
   rf_signal = observe_np(state, impulse)
 
   # Rotate back.
   rf_signal = tensor_utils.rotate_tensor_np(
-    rf_signal, [-1 * angle for angle in angles], 1)
+    rf_signal, [-1 * angle for angle in angles], 1, pad_and_trim=True)
 
   # Return RF data.
   return rf_signal

--- a/simulation/observation_test.py
+++ b/simulation/observation_test.py
@@ -397,8 +397,9 @@ class RotateAndObserveNpTest(tf.test.TestCase):
     for slice in range(6):
       truth.append(
         tensor_utils.rotate_tensor_np(
-          tensor_utils.rotate_tensor_np(state[:, np.newaxis, :, :, np.newaxis], [angles[slice]], 1),
-          [-1 * angles[slice]], 1
+          tensor_utils.rotate_tensor_np(
+            state[:, np.newaxis, :, :, np.newaxis], [angles[slice]], 1, True),
+          [-1 * angles[slice]], 1, True
         )
       )
     truth = np.concatenate(truth, 1)

--- a/simulation/tensor_utils_test.py
+++ b/simulation/tensor_utils_test.py
@@ -147,14 +147,14 @@ class RotateNumpyTest(tf.test.TestCase):
       tensor_utils.rotate_tensor_np(tensor, angles, rotation_axis)
 
   def testRotationNoBatch(self):
-    tensor = np.pad(np.random.rand(*[5] * 4), [[0,0], [1,1], [1,1], [0,0]], mode="constant")
-    angles = np.random.rand(5) * np.pi
+    tensor = np.pad(np.random.rand(*[10] * 4), [[0,0], [1,1], [1,1], [0,0]], mode="constant")
+    angles = np.random.rand(10) * np.pi
     rotation_axis = 0
     true_rotation = tf.contrib.image.rotate(tensor, angles, "BILINEAR")
     rotate = tensor_utils.rotate_tensor_np(tensor, angles, rotation_axis)
     with self.test_session() as sess:
       truth = sess.run(true_rotation)
-    self.assertAllClose(truth, rotate)
+    self.assertAllClose(truth, rotate, atol=.0001)
 
   def testRotationBatch(self):
     tensor = np.pad(np.random.rand(3, 7, 5, 5, 5),
@@ -167,6 +167,30 @@ class RotateNumpyTest(tf.test.TestCase):
         tensor[batch_iter], angles, "BILINEAR"))
     true_rotation = tf.stack(true_rotations, 0)
     rotate = tensor_utils.rotate_tensor_np(tensor, angles, rotation_axis)
+    with self.test_session() as sess:
+      truth = sess.run(true_rotation)
+    self.assertAllClose(truth, rotate)
+
+  def testRotationNoBatchPadAndTrim(self):
+    tensor = np.random.rand(*[10] * 4)
+    angles = np.random.rand(10) * np.pi
+    rotation_axis = 0
+    true_rotation = tf.contrib.image.rotate(tensor, angles, "BILINEAR")
+    rotate = tensor_utils.rotate_tensor_np(tensor, angles, rotation_axis, True)
+    with self.test_session() as sess:
+      truth = sess.run(true_rotation)
+    self.assertAllClose(truth, rotate, atol=.0001)
+
+  def testRotationBatchPadAndTrim(self):
+    tensor = np.random.rand(3, 7, 5, 5, 5)
+    angles = np.random.rand(7) * np.pi
+    rotation_axis = 1
+    true_rotations = []
+    for batch_iter in range(3):
+      true_rotations.append(tf.contrib.image.rotate(
+        tensor[batch_iter], angles, "BILINEAR"))
+    true_rotation = tf.stack(true_rotations, 0)
+    rotate = tensor_utils.rotate_tensor_np(tensor, angles, rotation_axis, True)
     with self.test_session() as sess:
       truth = sess.run(true_rotation)
     self.assertAllClose(truth, rotate)


### PR DESCRIPTION
CONTEXT: `np.rotate` uses a different filling algorithm than `tf.rotate`.